### PR TITLE
Fix issue#22: for over 100 notebooks or orphan notebooks

### DIFF
--- a/src/noteoverview.ts
+++ b/src/noteoverview.ts
@@ -389,7 +389,7 @@ export namespace noteoverview {
       logging.silly("load notebooks");
       joplinNotebooks = {};
       let queryFolders;
-      let pageQuery = 0;
+      let pageQuery = 1;
       do {
         try {
           queryFolders = await joplin.data.get(["folders"], {
@@ -409,15 +409,16 @@ export namespace noteoverview {
             parent_id: queryFolders.items[queryFolderKey].parent_id,
           };
         }
-        pageQuery++;
       } while (queryFolders.has_more);
 
       const getParentName = (id: string, notebookPath: string[]) => {
         if (id === "") return;
-        if (joplinNotebooks[id].parent_id !== "") {
-          getParentName(joplinNotebooks[id].parent_id, notebookPath);
+        if (joplinNotebooks[id]) { // To avoid orphan notebooks
+          if (joplinNotebooks[id].parent_id !== "") {
+            getParentName(joplinNotebooks[id].parent_id, notebookPath);
+          }
+          notebookPath.push(joplinNotebooks[id].title);
         }
-        notebookPath.push(joplinNotebooks[id].title);
       };
 
       for (const key in joplinNotebooks) {


### PR DESCRIPTION
It fixes the following symptoms described in issue #22.
(a) The plugin doesn't work if over 100 notebooks exist.
(b) The plugin doesn't work if orphan notebooks (notebooks whose parent_id point no existing notebooks) exist.

About (a), the current note-overview implementation fetch the data of notebooks incorrectly. The zero-th page, 2nd, 4th ... are fetched and 3rd page, 5th, ... are not fetched. The zero-th page is incorrect for Joplin Data API and is replaced to the first page. Each page contains max 50 notebooks. So, 100 or less notebooks (in the zero-th and 2nd pages) can be processed correctly. But, 101th notebook is not fetched, because it is in the third page.
As a result, notebook information becomes incomplete. It causes null reference errors.

About (b), if a notebook whose parent_id points no existing notebook exists, null reference errors occur. (b) is also the direct cause of failure of (a).

Although orphan notebooks rarely appear, some people who directly manipulate Joplin's data API sometimes happens to make them. 