### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Options that can be specified in the in the code block using YAML syntax.
 ### search
 
 The search filter which will be used to create the overview.
-[Documentation of search filters](https://joplinapp.org/#search-filters).
+[Documentation of search filters](https://joplinapp.org/help/#search-filters).
 
 ```yml
 search: type:todo


### PR DESCRIPTION
Update the broken link in [search](https://github.com/JackGruber/joplin-plugin-note-overview#search) section. 