### PR TITLE
Update README.md FAQ to explain that an open note will not be updated in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ For example change `text: {{title}}` to `text: "{{title}}"`
 
 ### My overview note is not being updated automatically
 
-The overview note will not be updated in the background if it's currently opened (i.e. displayed and/or edited).
+The overview note will not be updated in the background if it's currently openedis in the markdown editor, split view or in the WYSIWYG
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ For example change `text: {{title}}` to `text: "{{title}}"`
 
 ### My overview note is not being updated automatically
 
-The overview note will not be updated in the background if it's currently openedis in the markdown editor, split view or in the WYSIWYG
+The overview note will not be updated in the background if it's currently opened in the markdown editor, the split view or in the WYSIWYG editor
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,10 @@ For example change `text: {{title}} match` to `text: "{{title}} match"`
 If an option value starts with a `{` and and ends with a `}` the text is interpreted as object. Enclose the value with quotes.
 For example change `text: {{title}}` to `text: "{{title}}"`
 
+### My overview note is not being updated automatically
+
+The overview note will not be updated in the background if it's currently opened (i.e. displayed and/or edited).
+
 ## Develop
 
 ### Build


### PR DESCRIPTION
Update README.md FAQ to explain that an open note will not be updated in the background. I assume this is a common confusion.

Context:
https://github.com/JackGruber/joplin-plugin-note-overview/issues/51