### PR TITLE
new datetime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ alias: todo_due AS Due Date, notebook AS Folder
 
 ### datetime
 
-Customize datetime fromat for a single overview. Complete list of format can be found [here](https://momentjs.com/docs/#/displaying/format/)
+Customize datetime fromat for a single overview.
+
+Complete list of format can be found [here](https://momentjs.com/docs/#/displaying/format/).
+Default is Joplin global settings on `Tools` > `Options` > `General` > `Date format` and `Time format`
 
 ```yml
 datetime:
@@ -203,6 +206,8 @@ datetime:
     enabled: [true | false]
     withSuffix: [true | false]
 ```
+
+`withSuffix` : if `true`, add oriented duration `in a month`, `a month ago` instead of `a month` (with `false`). Default is `true`.
 
 ### image
 

--- a/README.md
+++ b/README.md
@@ -185,10 +185,7 @@ alias: todo_due AS Due Date, notebook AS Folder
 
 ### datetime
 
-Customize datetime fromat for a single overview.
-
-Complete list of format can be found [here](https://momentjs.com/docs/#/displaying/format/).
-Default is Joplin global settings on `Tools` > `Options` > `General` > `Date format` and `Time format`
+Customize datetime format for a single overview.
 
 ```yml
 datetime:
@@ -196,7 +193,12 @@ datetime:
   time: "HH:mm"
 ```
 
-you can also set datetime format to [humanize](https://momentjs.com/docs/#/durations/humanize/) format, to display a length of time. You can do that by adding `humanize: true`, like this
+- `date`: Set date format. Default is Joplin global settings on `Tools` > `Options` > `General` > `Date format`
+- `time`: Set time format. Default is Joplin global settings on `Tools` > `Options` > `General` > `Time format`
+
+Complete list of format can be found [here](https://momentjs.com/docs/#/displaying/format/).
+
+You can also set datetime to [humanize](https://momentjs.com/docs/#/durations/humanize/) format, to display a length of time. You can do that by adding `humanize` settings.
 
 ```yml
 datetime:
@@ -207,7 +209,8 @@ datetime:
     withSuffix: [true | false]
 ```
 
-`withSuffix` : if `true`, add oriented duration `in a month`, `a month ago` instead of `a month` (with `false`). Default is `true`.
+- `enabled` : set `true` to enable humanize format. Default is `false`.
+- `withSuffix` : set `false`, to remove oriented duration (ex: `a month`). Default is `true`, it will add oriented duration (ex: `in a month`, `a month ago`).
 
 ### image
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A note overview is created based on the defined search and the specified fields.
     - [fields](#fields)
     - [sort](#sort)
     - [alias](#alias)
+    - [datetime](#datetime)
     - [image](#image)
     - [excerpt](#excerpt)
     - [details](#details)
@@ -180,6 +181,27 @@ Syntax: `<field> AS <new field name>`, multiple fields comma seperated.
 
 ```yml
 alias: todo_due AS Due Date, notebook AS Folder
+```
+
+### datetime
+
+Customize datetime fromat for a single overview. Complete list of format can be found [here](https://momentjs.com/docs/#/displaying/format/)
+
+```yml
+datetime:
+  date: "YYYY-MM-DD"
+  time: "HH:mm"
+```
+
+you can also set datetime format to [humanize](https://momentjs.com/docs/#/durations/humanize/) format, to display a length of time. You can do that by adding `humanize: true`, like this
+
+```yml
+datetime:
+  date: "YYYY-MM-DD"
+  time: "HH:mm"
+  humanize:
+    enabled: [true | false]
+    withSuffix: [true | false]
 ```
 
 ### image

--- a/__test__/data/options/datetime.yml
+++ b/__test__/data/options/datetime.yml
@@ -1,0 +1,3 @@
+datetime:
+  date: "DD/MM/YYYY"
+  time: ""

--- a/__test__/data/options/datetime_humanize.yml
+++ b/__test__/data/options/datetime_humanize.yml
@@ -1,0 +1,5 @@
+datetime:
+  date: "DD/MM/YYYY"
+  time: "HH:mm"
+  humanize:
+    enabled: true

--- a/__test__/data/options/datetime_humanize_withoutSuffix.yml
+++ b/__test__/data/options/datetime_humanize_withoutSuffix.yml
@@ -1,0 +1,6 @@
+datetime:
+  date: "DD/MM/YYYY"
+  time: "HH:mm"
+  humanize:
+    enabled: true
+    withSuffix: false

--- a/__test__/datetime.test.ts
+++ b/__test__/datetime.test.ts
@@ -1,0 +1,90 @@
+import { noteoverview } from "../src/noteoverview";
+import { getOptionsFromFile } from "./tools";
+
+describe("Datetime function", function () {
+  it(`empty time format`, async () => {
+    const options = getOptionsFromFile("datetime");
+    const optionsObject = await noteoverview.getOptions(options);
+
+    const dateFormat = "DD/MM/YYYY";
+    const timeFormat = "";
+
+    const testDate = new Date();
+    const epoch = testDate.getTime();
+    const expectedDatetimeFormated = await noteoverview.getDateFormated(
+      epoch,
+      dateFormat,
+      timeFormat
+    );
+
+    const fields = {
+      todo_due: epoch,
+    };
+    const result = await noteoverview.getFieldValue(
+      "todo_due",
+      fields,
+      optionsObject
+    );
+    expect(result).toBe(`${expectedDatetimeFormated}`);
+  });
+
+  it(`humanize format`, async () => {
+    const options = getOptionsFromFile("datetime_humanize");
+    const optionsObject = await noteoverview.getOptions(options);
+
+    const dateFormat = "DD/MM/YYYY";
+    const timeFormat = "HH:mm";
+
+    const testDate = new Date();
+    testDate.setDate(new Date().getDate() + 1);
+    const epochTomorrow = testDate.getTime();
+    const expectedDatetimeFormated = await noteoverview.getDateFormated(
+      epochTomorrow,
+      dateFormat,
+      timeFormat
+    );
+
+    const fields = {
+      todo_due: epochTomorrow,
+    };
+    const result = await noteoverview.getFieldValue(
+      "todo_due",
+      fields,
+      optionsObject
+    );
+
+    expect(result).toBe(
+      `<font title=\"${expectedDatetimeFormated}\">in a day</font>`
+    );
+  });
+
+  it(`humanize without suffix format`, async () => {
+    const options = getOptionsFromFile("datetime_humanize_withoutSuffix");
+    const optionsObject = await noteoverview.getOptions(options);
+
+    const dateFormat = "DD/MM/YYYY";
+    const timeFormat = "HH:mm";
+
+    const testDate = new Date();
+    testDate.setDate(new Date().getDate() + 1);
+    const epochTomorrow = testDate.getTime();
+    const expectedDatetimeFormated = await noteoverview.getDateFormated(
+      epochTomorrow,
+      dateFormat,
+      timeFormat
+    );
+
+    const fields = {
+      todo_due: epochTomorrow,
+    };
+    const result = await noteoverview.getFieldValue(
+      "todo_due",
+      fields,
+      optionsObject
+    );
+
+    expect(result).toBe(
+      `<font title=\"${expectedDatetimeFormated}\">a day</font>`
+    );
+  });
+});

--- a/__test__/noteoverview.test.ts
+++ b/__test__/noteoverview.test.ts
@@ -51,6 +51,29 @@ describe("Date formating", function () {
       await noteoverview.getDateFormated(epoch, dateFormat, timeFormat)
     ).toBe("21/06/2021 15:30");
   });
+
+  it(`Get empty time string`, async () => {
+    const testDate = new Date(2021, 5, 21, 15, 30, 45);
+    const epoch = testDate.getTime();
+    const dateFormat = "DD/MM/YYYY";
+    const timeFormat = "[]";
+    expect(
+      await noteoverview.getDateFormated(epoch, dateFormat, timeFormat)
+    ).toBe("21/06/2021");
+  });
+
+  it(`Get humanize string`, async () => {
+    let epoch;
+    const testDate = new Date();
+    testDate.setDate(new Date().getDate() + 1);
+    epoch = testDate.getTime();
+
+    expect(await noteoverview.getDateHumanized(epoch)).toBe("in a day");
+
+    testDate.setDate(new Date().getDate() - 1);
+    epoch = testDate.getTime();
+    expect(await noteoverview.getDateHumanized(epoch)).toBe("a day ago");
+  });
 });
 
 describe("Singel tests", function () {

--- a/__test__/noteoverview.test.ts
+++ b/__test__/noteoverview.test.ts
@@ -51,29 +51,6 @@ describe("Date formating", function () {
       await noteoverview.getDateFormated(epoch, dateFormat, timeFormat)
     ).toBe("21/06/2021 15:30");
   });
-
-  it(`Get empty time string`, async () => {
-    const testDate = new Date(2021, 5, 21, 15, 30, 45);
-    const epoch = testDate.getTime();
-    const dateFormat = "DD/MM/YYYY";
-    const timeFormat = "[]";
-    expect(
-      await noteoverview.getDateFormated(epoch, dateFormat, timeFormat)
-    ).toBe("21/06/2021");
-  });
-
-  it(`Get humanize string`, async () => {
-    let epoch;
-    const testDate = new Date();
-    testDate.setDate(new Date().getDate() + 1);
-    epoch = testDate.getTime();
-
-    expect(await noteoverview.getDateHumanized(epoch)).toBe("in a day");
-
-    testDate.setDate(new Date().getDate() - 1);
-    epoch = testDate.getTime();
-    expect(await noteoverview.getDateHumanized(epoch)).toBe("a day ago");
-  });
 });
 
 describe("Singel tests", function () {

--- a/src/noteoverview.ts
+++ b/src/noteoverview.ts
@@ -174,12 +174,15 @@ export namespace noteoverview {
   ): Promise<string> {
     if (epoch !== 0) {
       const dateObject = new Date(epoch);
-      const dateString =
-        moment(dateObject.getTime()).format(dateFormat) +
-        " " +
-        moment(dateObject.getTime()).format(timeFormat);
+      const date: string = moment(dateObject.getTime()).format(dateFormat);
+      const time: string = moment(dateObject.getTime()).format(timeFormat);
 
-      return dateString;
+      const datetime: string[] = [date];
+      if (time !== "") {
+        datetime.push(time);
+      }
+
+      return datetime.join(" ");
     } else {
       return "";
     }

--- a/src/noteoverview.ts
+++ b/src/noteoverview.ts
@@ -187,14 +187,12 @@ export namespace noteoverview {
       return "";
     }
   }
-  export async function getDateHumanized(
-    epoch: number
-  ): Promise<string> {
+  export async function getDateHumanized(epoch: number): Promise<string> {
     if (epoch !== 0) {
       const dateObject = new Date(epoch);
-      const dateString = moment.duration(
-        moment(dateObject.getTime()).diff(moment())
-      ).humanize(true);
+      const dateString = moment
+        .duration(moment(dateObject.getTime()).diff(moment()))
+        .humanize(true);
 
       return dateString;
     } else {
@@ -840,7 +838,11 @@ export namespace noteoverview {
     settings.link = overviewSettings["link"] ? overviewSettings["link"] : null;
 
     settings.datetimeSettings = await mergeObject(
-      { "date": globalSettings.dateFormat, "time": globalSettings.timeFormat, "humanize": false },
+      {
+        date: globalSettings.dateFormat,
+        time: globalSettings.timeFormat,
+        humanize: false,
+      },
       overviewSettings["datetime"]
     );
 
@@ -1182,16 +1184,14 @@ export namespace noteoverview {
         value = await noteoverview.getDateFormated(
           dateObject.getTime(),
           options.datetimeSettings.date,
-          options.datetimeSettings.time,
+          options.datetimeSettings.time
         );
 
         const htmlAttr: string[] = [];
         if (value !== "" && options.datetimeSettings.humanize) {
           htmlAttr.push(`title="${value}"`);
 
-          value = await noteoverview.getDateHumanized(
-            dateObject.getTime()
-          );
+          value = await noteoverview.getDateHumanized(dateObject.getTime());
         }
 
         switch (field) {
@@ -1210,7 +1210,7 @@ export namespace noteoverview {
         }
 
         if (htmlAttr.length) {
-          value = `<font ${htmlAttr.join(' ')}>${value}</font>`;
+          value = `<font ${htmlAttr.join(" ")}>${value}</font>`;
         }
         break;
       case "status":

--- a/src/noteoverview.ts
+++ b/src/noteoverview.ts
@@ -175,7 +175,8 @@ export namespace noteoverview {
     if (epoch !== 0) {
       const dateObject = new Date(epoch);
       const date: string = moment(dateObject.getTime()).format(dateFormat);
-      const time: string = moment(dateObject.getTime()).format(timeFormat);
+      const newTimeFormat: string = timeFormat === "" ? "[]" : timeFormat;
+      const time: string = moment(dateObject.getTime()).format(newTimeFormat);
 
       const datetime: string[] = [date];
       if (time !== "") {
@@ -187,12 +188,15 @@ export namespace noteoverview {
       return "";
     }
   }
-  export async function getDateHumanized(epoch: number): Promise<string> {
+  export async function getDateHumanized(
+    epoch: number,
+    withSuffix: boolean = false
+  ): Promise<string> {
     if (epoch !== 0) {
       const dateObject = new Date(epoch);
       const dateString = moment
         .duration(moment(dateObject.getTime()).diff(moment()))
-        .humanize(true);
+        .humanize(withSuffix);
 
       return dateString;
     } else {
@@ -841,7 +845,10 @@ export namespace noteoverview {
       {
         date: globalSettings.dateFormat,
         time: globalSettings.timeFormat,
-        humanize: false,
+        humanize: {
+          enabled: false,
+          withSuffix: true,
+        },
       },
       overviewSettings["datetime"]
     );
@@ -1188,10 +1195,13 @@ export namespace noteoverview {
         );
 
         const htmlAttr: string[] = [];
-        if (value !== "" && options.datetimeSettings.humanize) {
+        if (value !== "" && options.datetimeSettings.humanize.enabled) {
           htmlAttr.push(`title="${value}"`);
 
-          value = await noteoverview.getDateHumanized(dateObject.getTime());
+          value = await noteoverview.getDateHumanized(
+            dateObject.getTime(),
+            options.datetimeSettings.humanize.withSuffix
+          );
         }
 
         switch (field) {

--- a/src/noteoverview.ts
+++ b/src/noteoverview.ts
@@ -190,7 +190,7 @@ export namespace noteoverview {
   }
   export async function getDateHumanized(
     epoch: number,
-    withSuffix: boolean = false
+    withSuffix: boolean
   ): Promise<string> {
     if (epoch !== 0) {
       const dateObject = new Date(epoch);

--- a/src/type.ts
+++ b/src/type.ts
@@ -13,6 +13,7 @@ type OverviewOptions = {
   listview: OverviewListview;
   escapeForTable: boolean;
   link: OverviewOptionsLink;
+  datetimeSettings: OverviewOptionsDatetime;
 };
 
 type OverviewOptionsLink = {
@@ -38,4 +39,9 @@ type OverviewListview = {
   suffix: string;
 };
 
+type OverviewOptionsDatetime = {
+  date: string;
+  time: string;
+  humanize: boolean;
+}
 export { OverviewOptions };

--- a/src/type.ts
+++ b/src/type.ts
@@ -42,6 +42,12 @@ type OverviewListview = {
 type OverviewOptionsDatetime = {
   date: string;
   time: string;
-  humanize: boolean;
+  humanize: OverviewOptionsDatetimeHumanize;
 };
+
+type OverviewOptionsDatetimeHumanize = {
+  enabled: boolean;
+  withSuffix: boolean;
+};
+
 export { OverviewOptions };

--- a/src/type.ts
+++ b/src/type.ts
@@ -43,5 +43,5 @@ type OverviewOptionsDatetime = {
   date: string;
   time: string;
   humanize: boolean;
-}
+};
 export { OverviewOptions };


### PR DESCRIPTION

<!-- TOC -->

- [Stories](#stories)
- [Datetime Settings](#datetime-settings)
- [Example](#example)
    - [Display date only](#display-date-only)
    - [Display humanize format](#display-humanize-format)
    - [Display humanize format without suffix](#display-humanize-format-without-suffix)

<!-- /TOC -->

### Stories

- i want to override date & time format settings (for todo_due, todo_completed, etc)

  so that date & time string rendered differently on other format, not using joplin default date time format.

- i want to read datetime format in [humanize](https://momentjs.com/docs/#/durations/humanize/) format

  so that i can overview my notes more user-friendly

introducing:

### Datetime Settings

```yml
<!-- note-overview-plugin
search: -tag:*
fields: updated_time, title
alias: updated_time AS Last edit, title AS Title
sort: title DESC
...
datetime:
  date: "YYYY-MM-DD"
  time: "HH:mm"
  humanize:
    enabled: [ true | false ]
    withSuffix: [ true | false ]
-->
```

`datetime.date` and `datetime.time` complete list of format can be found [here](https://momentjs.com/docs/#/displaying/format/)

### Example

#### Display date only

```yml
<!-- note-overview-plugin
...
datetime:
  time: ""
-->
```

| status | title                      | due                                  |
| ------ | -------------------------- | ------------------------------------ |
| ⚠      | [todo overdue](:/xxx)      | <font color="red">2023-12-10 </font> |
|        | [todo with duedate](:/xxx) | 2023-12-18                           |

#### Display humanize format

```yml
<!-- note-overview-plugin
...
datetime:
  humanize:
    enabled: true
-->
```

| status | title                      | due                                                          |
| ------ | -------------------------- | ------------------------------------------------------------ |
| ⚠      | [todo overdue](:/xxx)      | <font title="2023-12-10 00:00" color="red">4 days ago</font> |
|        | [todo with duedate](:/xxx) | <font title="2023-12-18 00:00">in 4 days</font>              |

---

#### Display humanize format without suffix

```yml
<!-- note-overview-plugin
...
datetime:
  humanize:
    enabled: true
    withSuffix: false
-->
```

| status | title                      | due                                                      |
| ------ | -------------------------- | -------------------------------------------------------- |
| ⚠      | [todo overdue](:/xxx)      | <font title="2023-12-10 00:00" color="red">4 days</font> |
|        | [todo with duedate](:/xxx) | <font title="2023-12-18 00:00">4 days</font>             |

---
